### PR TITLE
More general cleanup

### DIFF
--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -153,7 +153,7 @@ class Complex:
         origin = list(numpy.zeros(dim, dtype=int))
         self.origin = origin
         supremum = list(numpy.ones(dim, dtype=int))
-        self.suprenum = supremum
+        self.supremum = supremum
 
         x_parents = [tuple(self.origin)]
 
@@ -166,7 +166,7 @@ class Complex:
             self.C0.add_vertex(self.V[tuple(supremum)])
         else:
             self.C0 = Cell(0, 0, self.origin,
-                           self.suprenum)  # Initial cell object
+                           self.supremum)  # Initial cell object
             self.C0.add_vertex(self.V[tuple(origin)])
             self.C0.add_vertex(self.V[tuple(supremum)])
 
@@ -243,15 +243,15 @@ class Complex:
         self.perm_symmetry(i_s, x_parents2, xi2)
 
     def add_centroid(self):
-        """Split the central edge between the origin and suprenum of
+        """Split the central edge between the origin and supremum of
         a cell and add the new vertex to the complex"""
         self.centroid = list(
-            (numpy.array(self.origin) + numpy.array(self.suprenum)) / 2.0)
+            (numpy.array(self.origin) + numpy.array(self.supremum)) / 2.0)
         self.C0.add_vertex(self.V[tuple(self.centroid)])
         self.C0.centroid = self.centroid
 
-        # Disconnect origin and suprenum
-        self.V[tuple(self.origin)].disconnect(self.V[tuple(self.suprenum)])
+        # Disconnect origin and supremum
+        self.V[tuple(self.origin)].disconnect(self.V[tuple(self.supremum)])
 
         # Connect centroid to all other vertices
         for v in self.C0():
@@ -285,9 +285,9 @@ class Complex:
 
     # Graph structure method:
     # 0. Capture the indices of the initial cell.
-    # 1. Generate new origin and suprenum scalars based on current generation
+    # 1. Generate new origin and supremum scalars based on current generation
     # 2. Generate a new set of vertices corresponding to a new
-    #    "origin" and "suprenum"
+    #    "origin" and "supremum"
     # 3. Connected based on the indices of the previous graph structure
     # 4. Disconnect the edges in the original cell
 
@@ -303,13 +303,13 @@ class Complex:
         except IndexError:
             self.H.append([])
 
-        # Generate subcubes using every extreme vertex in C_i as a suprenum
+        # Generate subcubes using every extreme vertex in C_i as a supremum
         # and the centroid of C_i as the origin
         H_new = []  # list storing all the new cubes split from C_i
         for i, v in enumerate(C_i()[:-1]):
-            suprenum = tuple(v.x)
+            supremum = tuple(v.x)
             H_new.append(
-                self.construct_hypercube(origin_new, suprenum, gen, C_i.hg_n))
+                self.construct_hypercube(origin_new, supremum, gen, C_i.hg_n))
 
         for i, connections in enumerate(self.graph):
             # Present vertex V_new[i]; connect to all connections:
@@ -345,7 +345,7 @@ class Complex:
         return no_splits  # USED IN SHGO
 
     # @lru_cache(maxsize=None)
-    def construct_hypercube(self, origin, suprenum, gen, hgr,
+    def construct_hypercube(self, origin, supremum, gen, hgr,
                             printout=False):
         """
         Build a hypercube with triangulations symmetric to C0.
@@ -353,15 +353,15 @@ class Complex:
         Parameters
         ----------
         origin : vec
-        suprenum : vec (tuple)
+        supremum : vec (tuple)
         gen : generation
         hgr : parent homology group rank
         """
 
         # Initiate new cell
-        C_new = Cell(gen, hgr, origin, suprenum)
+        C_new = Cell(gen, hgr, origin, supremum)
         C_new.centroid = tuple(
-            (numpy.array(origin) + numpy.array(suprenum)) / 2.0)
+            (numpy.array(origin) + numpy.array(supremum)) / 2.0)
 
         # Build new indexed vertex list
         V_new = []
@@ -369,7 +369,7 @@ class Complex:
         # Cached calculation
         for i, v in enumerate(self.C0()[:-1]):
             t1 = self.generate_sub_cell_t1(origin, v.x)
-            t2 = self.generate_sub_cell_t2(suprenum, v.x)
+            t2 = self.generate_sub_cell_t2(supremum, v.x)
 
             vec = t1 + t2
 
@@ -390,7 +390,7 @@ class Complex:
         if printout:
             print("A sub hyper cube with:")
             print("origin: {}".format(origin))
-            print("suprenum: {}".format(suprenum))
+            print("supremum: {}".format(supremum))
             for v in C_new():
                 v.print_out()
 
@@ -464,9 +464,9 @@ class Complex:
         return
 
     @lru_cache(maxsize=None)
-    def generate_sub_cell_2(self, origin, suprenum, v_x_t):  # No hits
+    def generate_sub_cell_2(self, origin, supremum, v_x_t):  # No hits
         """
-        Use the origin and suprenum vectors to find a new cell in that
+        Use the origin and supremum vectors to find a new cell in that
         subspace direction
 
         NOTE: NOT CURRENTLY IN USE!
@@ -474,14 +474,14 @@ class Complex:
         Parameters
         ----------
         origin : tuple vector (hashable)
-        suprenum : tuple vector (hashable)
+        supremum : tuple vector (hashable)
 
         Returns
         -------
 
         """
         t1 = self.generate_sub_cell_t1(origin, v_x_t)
-        t2 = self.generate_sub_cell_t2(suprenum, v_x_t)
+        t2 = self.generate_sub_cell_t2(supremum, v_x_t)
         vec = t1 + t2
         return tuple(vec)
 
@@ -492,8 +492,8 @@ class Complex:
         return v_o - v_o * numpy.array(v_x)
 
     @lru_cache(maxsize=None)
-    def generate_sub_cell_t2(self, suprenum, v_x):
-        v_s = numpy.array(suprenum)
+    def generate_sub_cell_t2(self, supremum, v_x):
+        v_s = numpy.array(supremum)
         return v_s * numpy.array(v_x)
 
     # Plots
@@ -598,7 +598,6 @@ class VertexGroup(object):
         # cumulatively throughout its entire history
         self.C = []
 
-
     def __call__(self):
         return self.C
 
@@ -645,11 +644,11 @@ class Cell(VertexGroup):
     Contains a cell that is symmetric to the initial hypercube triangulation
     """
 
-    def __init__(self, p_gen, p_hgr, origin, suprenum):
+    def __init__(self, p_gen, p_hgr, origin, supremum):
         super(Cell, self).__init__(p_gen, p_hgr)
 
         self.origin = origin
-        self.suprenum = suprenum
+        self.supremum = supremum
         self.centroid = None  # (Not always used)
         # TODO: self.bounds
 

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -429,45 +429,45 @@ class Complex:
 
         # Find new vertex.
         # V_new_x = tuple((numpy.array(C()[0].x) + numpy.array(C()[1].x)) / 2.0)
-        V_new = self.V[
-            tuple((numpy.array(S()[0].x) + numpy.array(S()[-1].x)) / 2.0)]
+        s = S()
+        firstx = s[0].x
+        lastx = s[-1].x
+        V_new = self.V[tuple((numpy.array(firstx) + numpy.array(lastx)) / 2.0)]
 
         # Disconnect old longest edge
-        self.V[S()[0].x].disconnect(self.V[S()[-1].x])
+        self.V[firstx].disconnect(self.V[lastx])
 
         # Connect new vertices to all other vertices
-        for v in S()[:]:
+        for v in s[:]:
             v.connect(self.V[V_new.x])
 
         # New "lower" simplex
         S_new_l = Simplex(gen, S.hg_n, S.p_hgr_h, self.generation_cycle,
                           self.dim)
-        S_new_l.add_vertex(S()[0])
+        S_new_l.add_vertex(s[0])
         S_new_l.add_vertex(V_new)  # Add new vertex
-        for v in S()[1:-1]:  # Add all other vertices
+        for v in s[1:-1]:  # Add all other vertices
             S_new_l.add_vertex(v)
 
         # New "upper" simplex
         S_new_u = Simplex(gen, S.hg_n, S.p_hgr_h, S.generation_cycle, self.dim)
-        S_new_u.add_vertex(
-            S()[S_new_u.generation_cycle + 1])  # First vertex on new long edge
 
-        for v in S()[1:-1]:  # Remaining vertices
+        # First vertex on new long edge
+        S_new_u.add_vertex(s[S_new_u.generation_cycle + 1])
+
+        for v in s[1:-1]:  # Remaining vertices
             S_new_u.add_vertex(v)
 
-        for k, v in enumerate(S()[1:-1]):  # iterate through inner vertices
-            # for easier k / gci tracking
-            k += 1
-            if k == (S.generation_cycle + 1):
+        for k, v in enumerate(s[1:-1]):  # iterate through inner vertices
+            if k == S.generation_cycle:
                 S_new_u.add_vertex(V_new)
             else:
                 S_new_u.add_vertex(v)
 
-        S_new_u.add_vertex(S()[-1])  # Second vertex on new long edge
+        S_new_u.add_vertex(s[-1])  # Second vertex on new long edge
 
         self.H[gen].append(S_new_l)
-        if 1:
-            self.H[gen].append(S_new_u)
+        self.H[gen].append(S_new_u)
 
         return
 

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -396,7 +396,7 @@ class Complex:
 
     def split_simplex_symmetry(self, S, gen):
         """
-        Split a hypersimplex S into two sub simplcies by building a hyperplane
+        Split a hypersimplex S into two sub simplices by building a hyperplane
         which connects to a new vertex on an edge (the longest edge in
         dim = {2, 3}) and every other vertex in the simplex that is not
         connected to the edge being split.

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -394,13 +394,7 @@ class Complex:
             print("origin: {}".format(origin))
             print("suprenum: {}".format(suprenum))
             for v in C_new():
-                print("Vertex: {}".format(v.x))
-                constr = 'Connections: '
-                for vc in v.nn:
-                    constr += '{} '.format(vc.x)
-
-                print(constr)
-                print('Order = {}'.format(v.order))
+                v.print_out()
 
         # Append the new cell to the to complex
         self.H[gen].append(C_new)
@@ -646,13 +640,7 @@ class VertexGroup(object):
         Print the current cell to console
         """
         for v in self():
-            print("Vertex: {}".format(v.x))
-            constr = 'Connections: '
-            for vc in v.nn:
-                constr += '{} '.format(vc.x)
-
-            print(constr)
-            print('Order = {}'.format(v.order))
+            v.print_out()
 
 
 class Cell(VertexGroup):
@@ -750,6 +738,15 @@ class Vertex:
             self.check_min = False
 
         return self._min
+
+    def print_out(self):
+        print("Vertex: {}".format(self.x))
+        constr = 'Connections: '
+        for vc in self.nn:
+            constr += '{} '.format(vc.x)
+
+        print(constr)
+        print('Order = {}'.format(self.order))
 
 
 class VertexCache:

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -122,7 +122,6 @@ class Complex:
 
         # TODO: Assign functions to a the complex instead
         if symmetry:
-            pass
             self.generation_cycle = 1
             # self.centroid = self.C0()[-1].x
             # self.C0.centroid = self.centroid

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -179,15 +179,7 @@ class Complex:
         if printout:
             print("Initial hyper cube:")
             for v in self.C0():
-                print(self.C0())
-                print("Vertex: {}".format(v.x))
-                print("v.f: {}".format(v.f))
-                constr = 'Connections: '
-                for vc in v.nn:
-                    constr += '{} '.format(vc.x)
-
-                print(constr)
-                print('Order = {}'.format(v.order))
+                v.print_out()
 
     def perm(self, i_parents, x_parents, xi):
         # TODO: Cut out of for if outside linear constraint cutting planes

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -594,7 +594,7 @@ class Complex:
         return
 
 
-class VertexGroup:
+class VertexGroup(object):
     def __init__(self, p_gen, p_hgr, p_hgr_h):
         self.p_gen = p_gen  # parent generation
         self.p_hgr = p_hgr  # parent homology group rank
@@ -661,7 +661,7 @@ class Cell(VertexGroup):
     """
 
     def __init__(self, p_gen, p_hgr, p_hgr_h, origin, suprenum):
-        super().__init__(p_gen, p_hgr, p_hgr_h)
+        super(Cell, self).__init__(p_gen, p_hgr, p_hgr_h)
 
         self.origin = origin
         self.suprenum = suprenum
@@ -676,7 +676,7 @@ class Simplex(VertexGroup):
     """
 
     def __init__(self, p_gen, p_hgr, p_hgr_h, generation_cycle, dim):
-        super().__init__(p_gen, p_hgr, p_hgr_h)
+        super(Simplex, self).__init__(p_gen, p_hgr, p_hgr_h)
 
         self.generation_cycle = (generation_cycle + 1) % (dim - 1)
 

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -155,20 +155,23 @@ class Complex:
         supremum = list(numpy.ones(dim, dtype=int))
         self.supremum = supremum
 
-        x_parents = [tuple(self.origin)]
+        # tuple versions for indexing
+        origintuple = tuple(origin)
+        supremumtuple = tuple(supremum)
+
+        x_parents = [origintuple]
 
         if symmetry:
             self.C0 = Simplex(0, 0, 0, self.dim)  # Initial cell object
-            self.C0.add_vertex(self.V[tuple(origin)])
+            self.C0.add_vertex(self.V[origintuple])
 
             i_s = 0
             self.perm_symmetry(i_s, x_parents, origin)
-            self.C0.add_vertex(self.V[tuple(supremum)])
+            self.C0.add_vertex(self.V[supremumtuple])
         else:
-            self.C0 = Cell(0, 0, self.origin,
-                           self.supremum)  # Initial cell object
-            self.C0.add_vertex(self.V[tuple(origin)])
-            self.C0.add_vertex(self.V[tuple(supremum)])
+            self.C0 = Cell(0, 0, origin, supremum)  # Initial cell object
+            self.C0.add_vertex(self.V[origintuple])
+            self.C0.add_vertex(self.V[supremumtuple])
 
             i_parents = []
             self.perm(i_parents, x_parents, origin)

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -158,15 +158,14 @@ class Complex:
         x_parents = [tuple(self.origin)]
 
         if symmetry:
-            # self.C0 = Cell(0, 0, 0, self.origin, self.suprenum)
-            self.C0 = Simplex(0, 0, 0, 0, self.dim)  # Initial cell object
+            self.C0 = Simplex(0, 0, 0, self.dim)  # Initial cell object
             self.C0.add_vertex(self.V[tuple(origin)])
 
             i_s = 0
             self.perm_symmetry(i_s, x_parents, origin)
             self.C0.add_vertex(self.V[tuple(supremum)])
         else:
-            self.C0 = Cell(0, 0, 0, self.origin,
+            self.C0 = Cell(0, 0, self.origin,
                            self.suprenum)  # Initial cell object
             self.C0.add_vertex(self.V[tuple(origin)])
             self.C0.add_vertex(self.V[tuple(supremum)])
@@ -310,8 +309,7 @@ class Complex:
         for i, v in enumerate(C_i()[:-1]):
             suprenum = tuple(v.x)
             H_new.append(
-                self.construct_hypercube(origin_new, suprenum,
-                                         gen, C_i.hg_n, C_i.p_hgr_h))
+                self.construct_hypercube(origin_new, suprenum, gen, C_i.hg_n))
 
         for i, connections in enumerate(self.graph):
             # Present vertex V_new[i]; connect to all connections:
@@ -347,7 +345,7 @@ class Complex:
         return no_splits  # USED IN SHGO
 
     # @lru_cache(maxsize=None)
-    def construct_hypercube(self, origin, suprenum, gen, hgr, p_hgr_h,
+    def construct_hypercube(self, origin, suprenum, gen, hgr,
                             printout=False):
         """
         Build a hypercube with triangulations symmetric to C0.
@@ -361,7 +359,7 @@ class Complex:
         """
 
         # Initiate new cell
-        C_new = Cell(gen, hgr, p_hgr_h, origin, suprenum)
+        C_new = Cell(gen, hgr, origin, suprenum)
         C_new.centroid = tuple(
             (numpy.array(origin) + numpy.array(suprenum)) / 2.0)
 
@@ -436,7 +434,7 @@ class Complex:
             v.connect(self.V[V_new.x])
 
         # New "lower" simplex
-        S_new_l = Simplex(gen, S.hg_n, S.p_hgr_h, self.generation_cycle,
+        S_new_l = Simplex(gen, S.hg_n, self.generation_cycle,
                           self.dim)
         S_new_l.add_vertex(s[0])
         S_new_l.add_vertex(V_new)  # Add new vertex
@@ -444,7 +442,7 @@ class Complex:
             S_new_l.add_vertex(v)
 
         # New "upper" simplex
-        S_new_u = Simplex(gen, S.hg_n, S.p_hgr_h, S.generation_cycle, self.dim)
+        S_new_u = Simplex(gen, S.hg_n, S.generation_cycle, self.dim)
 
         # First vertex on new long edge
         S_new_u.add_vertex(s[S_new_u.generation_cycle + 1])
@@ -589,10 +587,9 @@ class Complex:
 
 
 class VertexGroup(object):
-    def __init__(self, p_gen, p_hgr, p_hgr_h):
+    def __init__(self, p_gen, p_hgr):
         self.p_gen = p_gen  # parent generation
         self.p_hgr = p_hgr  # parent homology group rank
-        self.p_hgr_h = p_hgr_h  #
         self.hg_n = None
         self.hg_d = None
 
@@ -648,8 +645,8 @@ class Cell(VertexGroup):
     Contains a cell that is symmetric to the initial hypercube triangulation
     """
 
-    def __init__(self, p_gen, p_hgr, p_hgr_h, origin, suprenum):
-        super(Cell, self).__init__(p_gen, p_hgr, p_hgr_h)
+    def __init__(self, p_gen, p_hgr, origin, suprenum):
+        super(Cell, self).__init__(p_gen, p_hgr)
 
         self.origin = origin
         self.suprenum = suprenum
@@ -663,8 +660,8 @@ class Simplex(VertexGroup):
     hypersimplex triangulation
     """
 
-    def __init__(self, p_gen, p_hgr, p_hgr_h, generation_cycle, dim):
-        super(Simplex, self).__init__(p_gen, p_hgr, p_hgr_h)
+    def __init__(self, p_gen, p_hgr, generation_cycle, dim):
+        super(Simplex, self).__init__(p_gen, p_hgr)
 
         self.generation_cycle = (generation_cycle + 1) % (dim - 1)
 

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -272,7 +272,6 @@ class Complex:
 
         for v in self.HC.C0():
             for v2 in v.nn:
-                # self.structure[0, 15] = 1
                 self.structure[v.Ind, v2.Ind] = 1
 
         return
@@ -365,9 +364,7 @@ class Complex:
         C_new = Cell(gen, hgr, p_hgr_h, origin, suprenum)
         C_new.centroid = tuple(
             (numpy.array(origin) + numpy.array(suprenum)) / 2.0)
-        # C_new.centroid =
 
-        # centroid_index = len(self.C0()) - 1
         # Build new indexed vertex list
         V_new = []
 
@@ -429,8 +426,6 @@ class Complex:
             self.H[gen]
         except IndexError:
             self.H.append([])
-        # gen, hgr, p_hgr_h,
-        # gen, C_i.hg_n, C_i.p_hgr_h
 
         # Find new vertex.
         # V_new_x = tuple((numpy.array(C()[0].x) + numpy.array(C()[1].x)) / 2.0)
@@ -463,18 +458,12 @@ class Complex:
         for k, v in enumerate(S()[1:-1]):  # iterate through inner vertices
             # for easier k / gci tracking
             k += 1
-            # if k == 0:
-            #    continue  # We do this rather than S[1:-1]
-            # for easier k / gci tracking
             if k == (S.generation_cycle + 1):
                 S_new_u.add_vertex(V_new)
             else:
                 S_new_u.add_vertex(v)
 
         S_new_u.add_vertex(S()[-1])  # Second vertex on new long edge
-
-        # for i, v in enumerate(S_new_u()):
-        #    print(f'S_new_u()[{i}].x = {v.x}')
 
         self.H[gen].append(S_new_l)
         if 1:
@@ -575,7 +564,6 @@ class Complex:
             pyplot.show()
 
         elif self.dim == 3:
-            from mpl_toolkits.mplot3d import Axes3D
             fig = pyplot.figure()
             ax = fig.add_subplot(111, projection='3d')
 
@@ -735,7 +723,6 @@ class Vertex:
             self.Ind = Ind
 
     def __hash__(self):
-        # return hash(tuple(self.x))
         return hash(self.x)
 
     def connect(self, v):
@@ -743,11 +730,7 @@ class Vertex:
             self.nn.add(v)
             v.nn.add(self)
 
-            # self.min = self.minimiser()
             if self.minimiser():
-                # if self.f > v.f:
-                #    self.min = False
-                # else:
                 v.min = False
                 v.check_min = False
 
@@ -787,7 +770,6 @@ class VertexCache:
                  g_cons_args=(), indexed=True):
 
         self.cache = {}
-        # self.cache = set()
         self.func = func
         self.g_cons = g_cons
         self.g_cons_args = g_cons_args
@@ -823,7 +805,6 @@ class VertexCache:
             # TODO: Check
             if self.func is not None:
                 if self.g_cons is not None:
-                    # print(f'xval.feasible = {xval.feasible}')
                     if xval.feasible:
                         self.nfev += 1
                         self.size += 1

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -729,7 +729,7 @@ class Vertex:
             v.nn.add(self)
 
             if self.minimiser():
-                v.min = False
+                v._min = False
                 v.check_min = False
 
             # TEMPORARY
@@ -744,14 +744,12 @@ class Vertex:
             v.check_min = True
 
     def minimiser(self):
-        # NOTE: This works pretty well, never call self.min,
-        #       call this function instead
+        """Check whether this vertex is strictly less than all its neighbours"""
         if self.check_min:
-            # Check if the current vertex is a minimiser
-            self.min = all(self.f < v.f for v in self.nn)
+            self._min = all(self.f < v.f for v in self.nn)
             self.check_min = False
 
-        return self.min
+        return self._min
 
 
 class VertexCache:

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -699,15 +699,11 @@ class Vertex:
         import numpy
         self.x = x
         self.order = sum(x)
-        if bounds is None:
-            x_a = numpy.array(x, dtype=float)
-        else:
-            x_a = numpy.array(x, dtype=float)
-            for i in range(len(bounds)):
-                x_a[i] = (x_a[i] * (bounds[i][1] - bounds[i][0])
-                          + bounds[i][0])
+        x_a = numpy.array(x, dtype=float)
+        if bounds is not None:
+            for i, (lb, ub) in enumerate(bounds):
+                x_a[i] = x_a[i] * (ub - lb) + lb
 
-                # print(f'x = {x}; x_a = {x_a}')
         # TODO: Make saving the array structure optional
         self.x_a = x_a
 

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -695,19 +695,17 @@ class Vertex:
         # TODO: Make saving the array structure optional
         self.x_a = x_a
 
-        # Note Vertex is only initiate once for all x so only
+        # Note Vertex is only initiated once for all x so only
         # evaluated once
         if func is not None:
+            self.feasible = True
             if g_cons is not None:
-                self.feasible = True
-                for ind, g in enumerate(g_cons):
-                    if g(self.x_a, *g_cons_args[ind]) < 0.0:
+                for g, args in zip(g_cons, g_cons_args):
+                    if g(self.x_a, *args) < 0.0:
                         self.f = numpy.inf
                         self.feasible = False
-                if self.feasible:
-                    self.f = func(x_a, *func_args)
-
-            else:
+                        break
+            if self.feasible:
                 self.f = func(x_a, *func_args)
 
         if nn is not None:

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -748,16 +748,7 @@ class Vertex:
         #       call this function instead
         if self.check_min:
             # Check if the current vertex is a minimiser
-            # self.min = all(self.f <= v.f for v in self.nn)
-            self.min = True
-            for v in self.nn:
-                # if self.f <= v.f:
-                # if self.f > v.f: #TODO: LAST STABLE
-                if self.f >= v.f:  # TODO: AttributeError: 'Vertex' object has no attribute 'f'
-                    # if self.f >= v.f:
-                    self.min = False
-                    break
-
+            self.min = all(self.f < v.f for v in self.nn)
             self.check_min = False
 
         return self.min

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -606,12 +606,8 @@ class Complex:
         return
 
 
-class Cell:
-    """
-    Contains a cell that is symmetric to the initial hypercube triangulation
-    """
-
-    def __init__(self, p_gen, p_hgr, p_hgr_h, origin, suprenum):
+class VertexGroup:
+    def __init__(self, p_gen, p_hgr, p_hgr_h):
         self.p_gen = p_gen  # parent generation
         self.p_hgr = p_hgr  # parent homology group rank
         self.p_hgr_h = p_hgr_h  #
@@ -622,10 +618,7 @@ class Cell:
         # This is the sum off all previously split cells
         # cumulatively throughout its entire history
         self.C = []
-        self.origin = origin
-        self.suprenum = suprenum
-        self.centroid = None  # (Not always used)
-        # TODO: self.bounds
+
 
     def __call__(self):
         return self.C
@@ -638,27 +631,20 @@ class Cell:
         """
         Returns the homology group order of the current cell
         """
-        if self.hg_n is not None:
-            return self.hg_n
-        else:
-            hg_n = 0
-            for v in self.C:
-                if v.minimiser():
-                    hg_n += 1
+        if self.hg_n is None:
+            self.hg_n = sum(1 for v in self.C if v.minimiser())
 
-            self.hg_n = hg_n
-            return hg_n
+        return self.hg_n
 
     def homology_group_differential(self):
         """
         Returns the difference between the current homology group of the
         cell and it's parent group
         """
-        if self.hg_d is not None:
-            return self.hg_d
-        else:
+        if self.hg_d is None:
             self.hgd = self.hg_n - self.p_hgr
-            return self.hgd
+
+        return self.hgd
 
     def polytopial_sperner_lemma(self):
         """
@@ -681,80 +667,30 @@ class Cell:
             print('Order = {}'.format(v.order))
 
 
-class Simplex:
+class Cell(VertexGroup):
+    """
+    Contains a cell that is symmetric to the initial hypercube triangulation
+    """
+
+    def __init__(self, p_gen, p_hgr, p_hgr_h, origin, suprenum):
+        super().__init__(p_gen, p_hgr, p_hgr_h)
+
+        self.origin = origin
+        self.suprenum = suprenum
+        self.centroid = None  # (Not always used)
+        # TODO: self.bounds
+
+
+class Simplex(VertexGroup):
     """
     Contains a simplex that is symmetric to the initial symmetry constrained
     hypersimplex triangulation
     """
 
     def __init__(self, p_gen, p_hgr, p_hgr_h, generation_cycle, dim):
-        self.p_gen = p_gen  # parent generation
-        self.p_hgr = p_hgr  # parent homology group rank
-        self.p_hgr_h = p_hgr_h  #
-        self.hg_n = None
-        self.hg_d = None
+        super().__init__(p_gen, p_hgr, p_hgr_h)
 
-        gci_n = (generation_cycle + 1) % (dim - 1)
-        gci = gci_n
-        self.generation_cycle = gci
-
-        # Maybe add parent homology group rank total history
-        # This is the sum off all previously split cells
-        # cumulatively throughout its entire history
-        self.C = []
-
-    def __call__(self):
-        return self.C
-
-    def add_vertex(self, V):
-        if V not in self.C:
-            self.C.append(V)
-
-    def homology_group_rank(self):
-        """
-        Returns the homology group order of the current cell
-        """
-        if self.hg_n is not None:
-            return self.hg_n
-        else:
-            hg_n = 0
-            for v in self.C:
-                if v.minimiser():
-                    hg_n += 1
-
-            self.hg_n = hg_n
-            return hg_n
-
-    def homology_group_differential(self):
-        """
-        Returns the difference between the current homology group of the
-        cell and it's parent group
-        """
-        if self.hg_d is not None:
-            return self.hg_d
-        else:
-            self.hgd = self.hg_n - self.p_hgr
-            return self.hgd
-
-    def polytopial_sperner_lemma(self):
-        """
-        Returns the number of stationary points theoretically contained in the
-        cell based information currently known about the cell
-        """
-        pass
-
-    def print_out(self):
-        """
-        Print the current cell to console
-        """
-        for v in self():
-            print("Vertex: {}".format(v.x))
-            constr = 'Connections: '
-            for vc in v.nn:
-                constr += '{} '.format(vc.x)
-
-            print(constr)
-            print('Order = {}'.format(v.order))
+        self.generation_cycle = (generation_cycle + 1) % (dim - 1)
 
 
 class Vertex:

--- a/shgo/shgo_m/triangulation.py
+++ b/shgo/shgo_m/triangulation.py
@@ -272,7 +272,7 @@ class Complex:
 
         for v in self.HC.C0():
             for v2 in v.nn:
-                self.structure[v.Ind, v2.Ind] = 1
+                self.structure[v.index, v2.index] = 1
 
         return
 
@@ -282,7 +282,7 @@ class Complex:
         incidence, each list element contains a list of indexes
         corresponding to that entries neighbours"""
 
-        self.graph = [[v2.Ind for v2 in v.nn] for v in self.C0()]
+        self.graph = [[v2.index for v2 in v.nn] for v in self.C0()]
 
     # Graph structure method:
     # 0. Capture the indices of the initial cell.
@@ -683,7 +683,7 @@ class Simplex(VertexGroup):
 
 class Vertex:
     def __init__(self, x, bounds=None, func=None, func_args=(), g_cons=None,
-                 g_cons_args=(), nn=None, Ind=None):
+                 g_cons_args=(), nn=None, index=None):
         import numpy
         self.x = x
         self.order = sum(x)
@@ -717,8 +717,8 @@ class Vertex:
         self.check_min = True
 
         # Index:
-        if Ind is not None:
-            self.Ind = Ind
+        if index is not None:
+            self.index = index
 
     def __hash__(self):
         return hash(self.x)
@@ -777,19 +777,19 @@ class VertexCache:
         self.size = 0
 
         if indexed:
-            self.Index = -1
+            self.index = -1
 
     def __getitem__(self, x, indexed=True):
         try:
             return self.cache[x]
         except KeyError:
             if indexed:
-                self.Index += 1
+                self.index += 1
                 xval = Vertex(x, bounds=self.bounds,
                               func=self.func, func_args=self.func_args,
                               g_cons=self.g_cons,
                               g_cons_args=self.g_cons_args,
-                              Ind=self.Index)
+                              index=self.index)
             else:
                 xval = Vertex(x, bounds=self.bounds,
                               func=self.func, func_args=self.func_args,


### PR DESCRIPTION
No big changes except for lots of code reduction due to extracting a superclass for Cell and Simplex, which were basically copy-pasted versions of each other.

Another notable small change is in using `_min` instead of `min` to store the "private" variable for the minimum value. This is a convention discussed in [PEP8's "Designing for inheritance"](https://www.python.org/dev/peps/pep-0008/#designing-for-inheritance) section.

I've also removed lots of vestigial commented bits of code. As I mentioned before, it is far better to split alternative implementations into different branches than to have this kind of stuff hanging around in the active code base, since it causes extra cognitive load when reading the code ("Why is this here, would that be better?").